### PR TITLE
Do not skip deploy plugin

### DIFF
--- a/opentracing-spring-messaging-starter/pom.xml
+++ b/opentracing-spring-messaging-starter/pom.xml
@@ -39,16 +39,4 @@
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${version.maven-deploy-plugin}</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/opentracing-spring-messaging/pom.xml
+++ b/opentracing-spring-messaging/pom.xml
@@ -76,13 +76,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${version.maven-deploy-plugin}</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>


### PR DESCRIPTION
@pavolloffay sorry I forgot to remove these deploy plugin configs after code transfer so your previous release only deployed parent pom...