### PR TITLE
Make all dependencies optional

### DIFF
--- a/opentracing-spring-messaging-starter/pom.xml
+++ b/opentracing-spring-messaging-starter/pom.xml
@@ -37,6 +37,17 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.integration</groupId>
+      <artifactId>spring-integration-core</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>

--- a/opentracing-spring-messaging/pom.xml
+++ b/opentracing-spring-messaging/pom.xml
@@ -32,14 +32,17 @@
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.integration</groupId>
       <artifactId>spring-integration-core</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-messaging</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Exposed dependencies cause class loader issues in java-spring-cloud. Will have to make another release in order to include this project to java-spring-cloud.