### PR TITLE
Fix issue with opentracing keys with dashes/hyphens and JMS. 

### DIFF
--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/JmsTextMapExtractAdapter.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/JmsTextMapExtractAdapter.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.integration.messaging;
+
+import io.opentracing.propagation.TextMap;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Helper class to extract span context from message properties
+ */
+public class JmsTextMapExtractAdapter implements TextMap {
+
+  private final Map<String, String> map = new HashMap<>();
+  static final String DASH = "_$dash$_";
+
+  public JmsTextMapExtractAdapter(TextMap message) {
+    if (message == null) {
+      return;
+    }
+    Iterator it = message.iterator();
+    while (it.hasNext()) {
+      Map.Entry headerPair = (Map.Entry) it.next();
+      String headerKey = (String) headerPair.getKey();
+      Object headerValue = headerPair.getValue();
+      if (headerValue instanceof String) {
+        map.put(decodeDash(headerKey), (String) headerValue);
+      }
+    }
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> iterator() {
+    return map.entrySet().iterator();
+  }
+
+  @Override
+  public void put(String key, String value) {
+    throw new UnsupportedOperationException(
+        "JmsTextMapExtractAdapter should only be used with Tracer.extract()");
+  }
+
+  private String decodeDash(String key) {
+    return key.replace(DASH, "-");
+  }
+}

--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/MessageTextMap.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/MessageTextMap.java
@@ -60,7 +60,7 @@ public class MessageTextMap<T> implements TextMap {
 
   @Override
   public void put(String key, String value) {
-    headers.put(key, byteHeaders.contains(key) ? value.getBytes() : value);
+    headers.put(encodeDash(key), byteHeaders.contains(key) ? value.getBytes() : value);
   }
 
   public Message<T> getMessage() {
@@ -68,4 +68,13 @@ public class MessageTextMap<T> implements TextMap {
       .copyHeaders(headers)
       .build();
   }
+
+  private String encodeDash(String key) {
+    if (key == null || key.isEmpty()) {
+      return key;
+    }
+
+    return key.replace("-", JmsTextMapExtractAdapter.DASH);
+  }
+
 }

--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptor.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -57,7 +57,7 @@ public class OpenTracingChannelInterceptor extends ChannelInterceptorAdapter imp
         .withTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), getChannelName(channel));
 
     MessageTextMap<?> carrier = new MessageTextMap<>(message);
-    SpanContext extractedContext = tracer.extract(Format.Builtin.TEXT_MAP, carrier);
+    SpanContext extractedContext = tracer.extract(Format.Builtin.TEXT_MAP, new JmsTextMapExtractAdapter(carrier));
     if (isConsumer) {
       spanBuilder.addReference(References.FOLLOWS_FROM, extractedContext);
     } else if (tracer.activeSpan() == null) {

--- a/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/JmsTextTextExtractAdapterTest.java
+++ b/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/JmsTextTextExtractAdapterTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+public class JmsTextTextExtractAdapterTest {
+
+  @Test
+  public void shouldGetIterator() {
+    Map<String, String> headers = new HashMap<>(2);
+    headers.put("h1", "v1");
+    headers.put("h2", "v2");
+    Message<String> message = MessageBuilder.withPayload("test").copyHeaders(headers).build();
+    MessageTextMap<String> map = new MessageTextMap<>(message);
+    JmsTextMapExtractAdapter adapter = new JmsTextMapExtractAdapter(map);
+    assertThat(adapter.iterator()).containsAll(headers.entrySet());
+  }
+
+  @Test
+  public void shouldDecodeDash() {
+    Map<String, String> headers = new HashMap<>(1);
+    headers.put("uber_$dash$_trace_$dash$_id", "v1");
+    Map<String, String> chanedHeaders = new HashMap<>(1);
+    headers.put("uber-trace-id", "v1");
+    Message<String> message = MessageBuilder.withPayload("test").copyHeaders(headers).build();
+    MessageTextMap<String> map = new MessageTextMap<>(message);
+    JmsTextMapExtractAdapter adapter = new JmsTextMapExtractAdapter(map);
+    assertThat(adapter.iterator()).containsAll(chanedHeaders.entrySet());
+  }
+
+}

--- a/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/MessageTextMapTest.java
+++ b/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/MessageTextMapTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -53,6 +53,16 @@ public class MessageTextMapTest {
     map.put("k1", "v1");
 
     assertThat(map.iterator()).contains(new AbstractMap.SimpleEntry<>("k1", "v1"));
+  }
+
+  @Test
+  public void shouldEncodeKeyWithDash() {
+    Message<String> message = MessageBuilder.withPayload("test")
+            .build();
+    MessageTextMap<String> map = new MessageTextMap<>(message);
+    map.put("uber-trace-id", "1435645");
+
+    assertThat(map.iterator()).contains(new AbstractMap.SimpleEntry<>("uber_$dash$_trace_$dash$_id", "1435645"));
   }
 
   @Test

--- a/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorTest.java
+++ b/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -122,7 +122,7 @@ public class OpenTracingChannelInterceptorTest {
     Message<?> message = interceptor.preSend(originalMessage, mockMessageChannel);
     assertThat(message.getPayload()).isEqualTo(originalMessage.getPayload());
 
-    verify(mockTracer).extract(eq(Format.Builtin.TEXT_MAP), any(MessageTextMap.class));
+    verify(mockTracer).extract(eq(Format.Builtin.TEXT_MAP), any(JmsTextMapExtractAdapter.class));
     verify(mockTracer).buildSpan(String.format("receive:%s", mockMessageChannel.toString()));
     verify(mockSpanBuilder).addReference(References.FOLLOWS_FROM, null);
     verify(mockSpanBuilder).startActive(true);


### PR DESCRIPTION
Encode the key names / replace any - character with _$dash$_ following [java-jms](https://github.com/opentracing-contrib/java-jms). This is definitely going to affect other transports as all keys with "-" character will be replaced with _$dash$_. So looking for suggestions

Fixes opentracing-contrib/java-spring-cloud#234